### PR TITLE
Make javascript code follow code style guide

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
             }
         },
         error: function() {
-            $( "body" ).append( '<p class="text-center">Error loading data. Please try again later.</p>' );
+            $( "body" ).append( "<p class='text-center'>Error loading data. Please try again later.</p>" );
         }
     });
 </script>


### PR DESCRIPTION
According to the jQuery [javascript style guide](http://contribute.jquery.org/style-guide/js/)

> Strings that require inner quoting must use double outside and single inside.
